### PR TITLE
Add group reference to runtime context.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-view",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "description": "View component and transforms for Vega visualizations.",
   "keywords": [
     "vega",

--- a/src/transforms/Mark.js
+++ b/src/transforms/Mark.js
@@ -20,14 +20,17 @@ export default function Mark(params) {
 var prototype = inherits(Mark, Transform);
 
 prototype.transform = function(_, pulse) {
-  var mark = this.value;
+  var mark = this.value, group, context;
 
-  // acquire mark on first invocation
+  // acquire mark on first invocation, bind context and group
   if (!mark) {
     mark = pulse.dataflow.scenegraph().mark(_.scenepath, _.markdef);
     mark.source = this;
     this.value = mark;
-    mark.group.context = _.scenepath.context;
+    context = _.scenepath.context;
+    group = mark.group;
+    group.context = context;
+    if (!context.group) context.group = group;
   }
 
   // initialize entering items


### PR DESCRIPTION
Updates the `Mark` operator to all add a `group` pointer to the runtime context object (if not already present) upon first invocation. This enables expression functions to access the appropriate `group` instance for the invocation scope.