### PR TITLE
Add Identifier transform.

### DIFF
--- a/definitions/Identifier.js
+++ b/definitions/Identifier.js
@@ -1,0 +1,7 @@
+export default {
+  "type": "Identifier",
+  "metadata": {"modifies": true},
+  "params": [
+    { "name": "as", "type": "string", "required": true }
+  ]
+};

--- a/index.js
+++ b/index.js
@@ -1,10 +1,15 @@
-import {transform} from 'vega-dataflow';
+import {register, transform} from 'vega-dataflow';
 
 import Bound from './src/transforms/Bound';
+import Identifier from './src/transforms/Identifier';
 import Mark from './src/transforms/Mark';
 import Overlap from './src/transforms/Overlap';
 import Render from './src/transforms/Render';
 import ViewLayout from './src/transforms/ViewLayout';
+
+import IdentifierDefinition from './definitions/Identifier';
+
+register(IdentifierDefinition, Identifier);
 
 transform('Bound', Bound);
 transform('Mark', Mark);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega-view",
-  "version": "1.0.0-beta.39",
+  "version": "1.0.0-beta.40",
   "description": "View component and transforms for Vega visualizations.",
   "keywords": [
     "vega",

--- a/src/transforms/Identifier.js
+++ b/src/transforms/Identifier.js
@@ -1,0 +1,42 @@
+import {Transform} from 'vega-dataflow';
+import {inherits} from 'vega-util';
+
+var COUNTER_NAME = ':vega_identifier:';
+
+/**
+ * Adds a unique identifier to all added tuples.
+ * This transform creates a new signal that serves as an id counter.
+ * As a result, the id counter is shared across all instances of this
+ * transform, generating unique ids across multiple data streams. In
+ * addition, this signal value can be included in a snapshot of the
+ * dataflow state, enabling correct resumption of id allocation.
+ * @constructor
+ * @param {object} params - The parameters for this operator.
+ * @param {string} params.as - The field name for the generated identifier.
+ */
+export default function Identifier(params) {
+  Transform.call(this, 0, params);
+}
+
+var prototype = inherits(Identifier, Transform);
+
+prototype.transform = function(_, pulse) {
+  var counter = getCounter(pulse.dataflow),
+      id = counter.value,
+      as = _.as;
+
+  pulse.visit(pulse.ADD, function(t) {
+    if (!t[as]) t[as] = ++id;
+  });
+
+  counter.set(this.value = id);
+  return pulse;
+};
+
+function getCounter(view) {
+  var counter = view._signals[COUNTER_NAME];
+  if (!counter) {
+    view._signals[COUNTER_NAME] = (counter = view.add(0));
+  }
+  return counter;
+}


### PR DESCRIPTION
Adds an `identifier` transform for assigning unique ids to data tuples. All instances of the transform will use a shared counter to ensure distinct ids are allocated regardless of data source (i.e., multiple instances of the transform will use the same, shared counter). Identifiers are guaranteed to be unique within a View instance (but not _across_ different Views). The id counter is stored on an internal signal that is serialized as part of a `getState` call.