### PR TITLE
fixed bug in adjusting viewBounds for legends

### DIFF
--- a/src/transforms/ViewLayout.js
+++ b/src/transforms/ViewLayout.js
@@ -94,7 +94,7 @@ function layoutGroup(view, group, _) {
     for (i=0, n=legends.length; i<n; ++i) {
       b = layoutLegend(view, legends[i], flow, xBounds, yBounds, width, height);
       (_.autosize && _.autosize.type === Fit)
-        ? viewBounds.add(b.x1, 0).add(b.x2, 0)
+        ? viewBounds.add(b.x1, b.y1).add(b.x2, b.y2)
         : viewBounds.union(b);
     }
   }

--- a/src/transforms/ViewLayout.js
+++ b/src/transforms/ViewLayout.js
@@ -97,14 +97,14 @@ function layoutGroup(view, group, _) {
         var orient = legends[i].items[0].datum.orient;
         if (orient === 'left' || orient === 'right') {
           viewBounds.add(b.x1, 0).add(b.x2, 0);
+          continue;
         }
         else if (orient === 'top' || orient === 'bottom') {
           viewBounds.add(0, b.y1).add(0, b.y2);
+          continue;
         }
       }
-      else {
-        viewBounds.union(b);
-      }
+      viewBounds.union(b);
     }
   }
 

--- a/src/transforms/ViewLayout.js
+++ b/src/transforms/ViewLayout.js
@@ -94,17 +94,18 @@ function layoutGroup(view, group, _) {
     for (i=0, n=legends.length; i<n; ++i) {
       b = layoutLegend(view, legends[i], flow, xBounds, yBounds, width, height);
       if (_.autosize && _.autosize.type === Fit) {
+        // for autosize fit, incorporate the orthogonal dimension only
+        // legends that overrun the chart area will then be clipped
+        // otherwise the chart area gets reduced to nothing!
         var orient = legends[i].items[0].datum.orient;
         if (orient === 'left' || orient === 'right') {
           viewBounds.add(b.x1, 0).add(b.x2, 0);
-          continue;
-        }
-        else if (orient === 'top' || orient === 'bottom') {
+        } else if (orient === 'top' || orient === 'bottom') {
           viewBounds.add(0, b.y1).add(0, b.y2);
-          continue;
         }
+      } else {
+        viewBounds.union(b);
       }
-      viewBounds.union(b);
     }
   }
 

--- a/src/transforms/ViewLayout.js
+++ b/src/transforms/ViewLayout.js
@@ -93,9 +93,18 @@ function layoutGroup(view, group, _) {
 
     for (i=0, n=legends.length; i<n; ++i) {
       b = layoutLegend(view, legends[i], flow, xBounds, yBounds, width, height);
-      (_.autosize && _.autosize.type === Fit)
-        ? viewBounds.add(b.x1, b.y1).add(b.x2, b.y2)
-        : viewBounds.union(b);
+      if (_.autosize && _.autosize.type === Fit) {
+        var orient = legends[i].items[0].datum.orient;
+        if (orient === 'left' || orient === 'right') {
+          viewBounds.add(b.x1, 0).add(b.x2, 0);
+        }
+        else if (orient === 'top' || orient === 'bottom') {
+          viewBounds.add(0, b.y1).add(0, b.y2);
+        }
+      }
+      else {
+        viewBounds.union(b);
+      }
     }
   }
 


### PR DESCRIPTION
The y values were not taken into consideration when adjusting the view bounds for legends. This causes issues when the legend orient is either 'top' or 'bottom'.